### PR TITLE
hotfix:Fixed player oriented diagonally when moving to the side

### DIFF
--- a/scripts/player/player_movement.gd
+++ b/scripts/player/player_movement.gd
@@ -35,7 +35,7 @@ func _horizontal_movement(delta):
 
 	direction = (direction + current_direction).normalized()
 
-	$Pivot.basis = Basis.looking_at(Vector3(direction[0] or 0.001, 0, direction[1]))
+	$Pivot.basis = Basis.looking_at(Vector3(direction[0] if direction[0] else 0.001, 0, direction[1]))
 
 	vel.x = direction.x * speed
 	vel.z = direction.y * speed


### PR DESCRIPTION
# Title
hotfix: Fixed player orientation when moving to the side

# Description
The player was oriented diagonally when moving to the side due to a questionable or statement in the basis.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Still works like it should (no critical bugs introduced)
