### PR TITLE
fix: item moveable fixed with colliosion layer player

### DIFF
--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -38,7 +38,7 @@ radius = 0.75
 
 [node name="Player" type="CharacterBody3D" groups=["Players"]]
 collision_layer = 2
-collision_mask = 11
+collision_mask = 3
 script = ExtResource("1_c8kx5")
 
 [node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="."]


### PR DESCRIPTION
# fix: move item is fixed

# Description

moveable item doen't stick to player or accelerate faster than should.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Compiles without errors
- [ ] Still builds
- [ ] Still works like it should (no critical bugs introduced)
