### PR TITLE
Fix: lobby exit portal

### DIFF
--- a/autoloads/Network.gd
+++ b/autoloads/Network.gd
@@ -15,6 +15,8 @@ var max_client_connections = 3
 var loaded_world = preload("res://scenes/lobby/lobby.tscn")
 var loaded_menu = preload("res://scenes/menu/menu.tscn")
 
+const LOBBY_PATH = "/root/Main/SpawnedItems/Lobby"
+
 var inverted = 1
 var other_team_member_id = null
 var other_team_member_node = null
@@ -132,8 +134,10 @@ func _on_leave_button_pressed():
 	if world:
 		world.queue_free()
 	get_node("/root/Main/SpawnedItems").remove_child(world)
+	var lobby = get_node_or_null(LOBBY_PATH)
+	if lobby:
+		lobby.queue_free()
 	get_node("/root/Main/SpawnedItems").add_child(loaded_menu.instantiate())
-
 
 
 func _on_server_disconnected():


### PR DESCRIPTION
# Title

Fix: lobby exit portal

# Description

At first when leaving the lobby through the purple portal, the lobby was still in the background with the host/join buttons as overlay, Now it should fully load to title screen without the lobby in the background.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please make sure there are no compilation errors and that you have build the code before you try merging it

- [ ] Still works like it should (no critical bugs introduced)
